### PR TITLE
[Bug Fix] Fix Null `piece` being passed from front end to back end.

### DIFF
--- a/client/src/components/chess/ChessContainer.js
+++ b/client/src/components/chess/ChessContainer.js
@@ -6,20 +6,19 @@ function ChessContainer({ game, playerId, makeMove }) {
 
     const [selectedSquare, setSelectedSquare] = useState(null);
     const handleSquareClick = (rowIndex, cellIndex) => {
-        console.log("inside handle click square");
-        const actualRow = getPlayerColor(game, playerId) === ChessColor.BLACK ? 7 - rowIndex : rowIndex;
-        const selectedPiece = game.board[actualRow][cellIndex];
-        console.log("clicking on ", actualRow, cellIndex, selectedPiece);
-
-        // If a piece is already selected
         if (selectedSquare) {
+            const actualRow = getPlayerColor(game, playerId) === ChessColor.BLACK ? 7 - selectedSquare.row : selectedSquare.row;
+            const selectedPiece = game.board[actualRow][selectedSquare.col];
             // Execute the move if it's valid (You can add more validation checks here)
             makeMove(selectedSquare, { row: rowIndex, col: cellIndex }, selectedPiece);
             setSelectedSquare(null);
-        } else if (selectedPiece && ((selectedPiece === selectedPiece.toUpperCase() && getPlayerColor(game, playerId) === ChessColor.WHITE) || (selectedPiece !== selectedPiece.toUpperCase() && getPlayerColor(game, playerId) === ChessColor.BLACK))) {
-            console.log("setting selected piece to ", rowIndex, cellIndex);
-            setSelectedSquare({ row: rowIndex, col: cellIndex });
-
+        } else {
+            const actualRow = getPlayerColor(game, playerId) === ChessColor.BLACK ? 7 - rowIndex : rowIndex;
+            const selectedPiece = game.board[actualRow][cellIndex];
+            if (selectedPiece && ((selectedPiece === selectedPiece.toUpperCase() && getPlayerColor(game, playerId) === ChessColor.WHITE) || (selectedPiece !== selectedPiece.toUpperCase() && getPlayerColor(game, playerId) === ChessColor.BLACK))) {
+                console.log("setting selected piece to ", rowIndex, cellIndex);
+                setSelectedSquare({ row: rowIndex, col: cellIndex });
+            }
         }
     };
     const lastMove = game.moves.length > 0 ? game.moves[game.moves.length - 1] : null;

--- a/client/src/components/chess/Moves.css
+++ b/client/src/components/chess/Moves.css
@@ -1,0 +1,3 @@
+.piece-img-moves {
+    vertical-align: middle;
+}

--- a/client/src/components/chess/Moves.js
+++ b/client/src/components/chess/Moves.js
@@ -1,5 +1,5 @@
 import { graphics, ChessColor } from './ChessLib';
-import './CapturedPieces.css';
+import './Moves.css';
 
 function Moves({ game }) {
     if (!game) return null; // Return null for React components when nothing should be rendered
@@ -17,7 +17,7 @@ function Moves({ game }) {
                     <img
                         src={graphics[`${move.piece.toLowerCase()}-${move.color === ChessColor.WHITE ? "white" : "black"}`]}
                         alt={`piece ${move.piece}`}
-                        className="piece-img"
+                        className="piece-img-moves"
                     />
                 )}
                 from {move.from} to {move.to}


### PR DESCRIPTION
When the client calls `makeMove` in the socket, it passes in `to`, `from`, and `piece`.

`piece` is found by the client from the board.  But we are currently getting it from the target square we are moving to, instead of the `selectedSquare` we are moving from. 

Fix this. 

Before this was breaking `Moves.js` rendering, but we patched that prior to this PR.

Also straightened out some css to make the head in the moves vertically centered with text.
